### PR TITLE
fix #1

### DIFF
--- a/Fastimage.php
+++ b/Fastimage.php
@@ -211,8 +211,7 @@ class FastImage
 		$result = substr($this->str, $this->strpos, $n);
 		$this->strpos += $n;
 		
-		// we are dealing with bytes here, so force the encoding
-		return mb_convert_encoding($result, "8BIT");
+		return $result;
 	}
 
 


### PR DESCRIPTION
The bug is: mb_convert_encoding() takes a 3rd argument (`$from_encoding`), which defaults to mb_internal_encoding().
So Fastimage is dependent upon the currently runtime configured internal encoding.
Converting to `8bit` has no effect, except removing high-ASCII character when `$from_encoding` is `UTF-8`.
So, just removing seems the right fix.
