### PR TITLE
Reset $type and $str on close() to enable subsequent uses of load()

### DIFF
--- a/Fastimage.php
+++ b/Fastimage.php
@@ -36,7 +36,13 @@ class FastImage
 
 	public function close()
 	{
-		if ($this->handle) fclose($this->handle);
+		if ($this->handle)
+		{
+			fclose($this->handle);
+			$this->handle = null;
+			$this->type = null;
+			$this->str = null;
+		}
 	}
 
 
@@ -229,7 +235,7 @@ class FastImage
 	{
 		$size = unpack("C*", $str);
 		
-	    	return ($size[1] << 8) + $size[2];
+		return ($size[1] << 8) + $size[2];
 	}
 
 


### PR DESCRIPTION
Unless `$type` is reset before a subsequent call to `load()`, it won't be determined again which may result in a wrong type and thus looking at the wrong bytes for the image dimensions.

`$str` has to be reset too, because otherwise we will read from the previous image data instead of the one from the current handle.